### PR TITLE
Added 'import time' fixes #10

### DIFF
--- a/pyparticleio/ParticleCloud.py
+++ b/pyparticleio/ParticleCloud.py
@@ -4,6 +4,7 @@ from sseclient import SSEClient
 from hammock import Hammock
 import traceback
 import json
+import time
 
 requests.packages.urllib3.disable_warnings()
 


### PR DESCRIPTION
 exception handling block in _event_loop() calls time.sleep() but time module wasn't imported.